### PR TITLE
Fix `plugins` option being ignored

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -187,6 +187,11 @@ function acornParse(code,config) {
         onComment:comments
     } ;
 
+    if (config)
+        for (var k in config)
+            if (k !== 'noNodentExtensions' && k != 'onParserInstallation')
+                options[k] = config[k] ;
+
     if (!(config && config.noNodentExtensions) || parseInt(acorn.version) < 4) {
         if (!alreadyInstalledPlugin) {
             if (parseInt(acorn.version) < 4)
@@ -199,11 +204,6 @@ function acornParse(code,config) {
         options.plugins.asyncawait = {asyncExits:true, awaitAnywhere:true} ;
     }
     
-    if (config)
-        for (var k in config)
-            if (k !== 'noNodentExtensions' && k != 'onParserInstallation')
-                options[k] = config[k] ;
-
     var ast = acorn.parse(code,options) ;
 
     // attach comments to the most tightly containing node


### PR DESCRIPTION
Hi there - `parseCode()` was checking for `options.plugins` before options had been augmented with user-supplied values from `config`. This meant that one couldn't supply a list of existing plugins to use: `{ plugins: { jsx: true } }`.