### PR TITLE
Support object spread destructuring

### DIFF
--- a/output.js
+++ b/output.js
@@ -700,7 +700,7 @@ var traveler = {
         if (node.properties.length > 0) {
             var properties = node.properties, length = properties.length;
             for (var i = 0; ; ) {
-                this.out(properties[i], state,'Property');
+                this.out(properties[i], state, properties[i].type);
                 if (++i < length)
                     state.write(null, ', ');
                  else

--- a/tests/semantics/dual-destructure.js
+++ b/tests/semantics/dual-destructure.js
@@ -16,6 +16,11 @@ async function arraySpread() {
   return [a,b].toString()
 }
 
+async function objectSpread() {
+  const {a, ...b} = await nop({ a: 1, b: 2 });
+  return [a,b].toString()
+}
+
 // fails in transform
 async function arrayElide() {
   const [,a,,b] = await nop([1, 2, 3, 4]);
@@ -60,5 +65,5 @@ async function assignArray() {
 return [
   await trivialArray(),await trivialObject(),await rename(),await key(),
   await nestedArray(),await nestedObject(),await indirect(), await arrayElide(),
-  await arraySpread(), await assignObj(), await assignArray()
+  await arraySpread(), await objectSpread(), await assignObj(), await assignArray()
 ].toString() ;


### PR DESCRIPTION
The following two examples cause a `TypeError: Cannot read property 'type' of undefined` in the `nodent-compiler` version 3.2.10.

```js
var { a, ...rest } = o;
```
[Demo](http://nodent.mailed.me.uk/#var%20%7B%20a%2C%20...rest%20%7D%20%3D%20o%3B~options~%7B%22mode%22%3A%22generators%22%2C%22promiseType%22%3A%22native%22%2C%22noRuntime%22%3Atrue%2C%22es6target%22%3Afalse%2C%22wrapAwait%22%3Afalse%2C%22spec%22%3Afalse%7D)

and

```js
function f({a, ...rest}) {}
```
[Demo](http://nodent.mailed.me.uk/#function%20f(%7Ba%2C%20...rest%7D)%20%7B%7D~options~%7B%22mode%22%3A%22generators%22%2C%22promiseType%22%3A%22native%22%2C%22noRuntime%22%3Atrue%2C%22es6target%22%3Afalse%2C%22wrapAwait%22%3Afalse%2C%22spec%22%3Afalse%7D)

This PR fixes it by modifying the `ObjectPattern` handler to call the handler for the actual property type instead of always going to the `Property` handler.

I also added a test that fails without this fix to catch regressions.

Closes MatAtBread/nodent#113